### PR TITLE
allow listing clusters and add help text

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,3 +127,7 @@ def test_looks_like_url():
     assert zalando_kubectl.main.looks_like_url('https://localhost')
     assert zalando_kubectl.main.looks_like_url('http://localhost')
     assert zalando_kubectl.main.looks_like_url('foo.example.org')
+
+
+def test_print_help():
+    zalando_kubectl.main.print_help()

--- a/zalando_kubectl/main.py
+++ b/zalando_kubectl/main.py
@@ -212,6 +212,12 @@ All other commands are forwarded to kubectl:
             ''')
 
 
+def do_login(args):
+    url = login(args)
+    with Action('Writing kubeconfig for {}..'.format(url)):
+        kube_config.update(url)
+
+
 def main(args=None):
     try:
         if not args:
@@ -219,7 +225,7 @@ def main(args=None):
         cmd = ''.join(args[1:2])
         cmd_args = args[2:]
         if cmd == 'login':
-            kube_config.update(login(cmd_args))
+            do_login(cmd_args)
         elif cmd == 'configure':
             configure(cmd_args)
         elif cmd == 'dashboard':


### PR DESCRIPTION
Another usability improvement:

* allow listing clusters with `zkubectl list-clusters`
* show help text with `zkubectl help` or `zkubectl -h`
* add informational output for `zkubectl login` (most users expect some output/feedback..)