### PR TITLE
Allow `completion` without authentication

### DIFF
--- a/zalando_kubectl/main.py
+++ b/zalando_kubectl/main.py
@@ -235,6 +235,8 @@ def main(args=None):
             configure(cmd_args)
         elif cmd == 'dashboard':
             dashboard(cmd_args)
+        elif cmd == 'completion':
+            proxy()
         elif cmd in ('list', 'list-clusters'):
             list_clusters(cmd_args)
         else:


### PR DESCRIPTION
 You can't start a shell if you have `source <(zkubectl completion zsh | sed 's/kubectl/zkubectl/g')` in your `.zshrc` and no network